### PR TITLE
Fix Claude session resume using -r flag

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "claude-agents",
   "displayName": "Claude Agents",
   "description": "Manage multiple Claude Code agents in parallel with git worktrees",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "your-publisher-id",
   "engines": {
     "vscode": "^1.85.0"

--- a/vscode-extension/src/agentManager.ts
+++ b/vscode-extension/src/agentManager.ts
@@ -464,10 +464,18 @@ export class AgentManager {
 
         const claudeCmd = getConfigService().claudeCommand;
 
-        // Start Claude with session ID for this agent
-        const cmd = `${claudeCmd} --session-id "${agent.sessionId}"`;
+        // Use -r to resume if session was previously started, otherwise create new with --session-id
+        const cmd = agent.sessionStarted
+            ? `${claudeCmd} -r "${agent.sessionId}"`
+            : `${claudeCmd} --session-id "${agent.sessionId}"`;
         agent.terminal!.show();
         agent.terminal!.sendText(cmd);
+
+        // Mark session as started so future calls will resume
+        if (!agent.sessionStarted) {
+            agent.sessionStarted = true;
+            this.saveAgents();
+        }
 
         // Set initial status to waiting-input (Claude starts waiting for user input)
         agent.status = 'waiting-input';

--- a/vscode-extension/src/services/PersistenceService.ts
+++ b/vscode-extension/src/services/PersistenceService.ts
@@ -71,6 +71,7 @@ export class PersistenceService {
                 repoPath: agent.repoPath,
                 taskFile: agent.taskFile,
                 isolationTier: agent.isolationTier,
+                sessionStarted: agent.sessionStarted,
             });
         }
 

--- a/vscode-extension/src/types/agent.ts
+++ b/vscode-extension/src/types/agent.ts
@@ -41,6 +41,8 @@ export interface PersistedAgent {
     repoPath: string;
     taskFile: string | null;
     isolationTier?: IsolationTier;
+    /** Whether Claude has been started with this sessionId (use -r to resume if true) */
+    sessionStarted?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix session resume logic when terminal is closed and reopened
- Add `sessionStarted` boolean to track if Claude has been started for an agent
- Use `-r <sessionId>` to resume existing sessions, `--session-id <sessionId>` for new ones
- Bump version to 0.1.2

## Problem
When a terminal was closed and reopened, clicking "Start Claude" would try to create a new session with `--session-id <id>`, which fails if the session already exists. Now it correctly uses `-r <id>` to resume.

## Test plan
- [x] Close an agent terminal with an active Claude session
- [x] Reopen terminal and click "Start Claude"
- [x] Verify Claude resumes the existing session instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)