### PR TITLE
Add TODO display and fix WSL Remote support

### DIFF
--- a/vscode-extension/compile_and_install.sh
+++ b/vscode-extension/compile_and_install.sh
@@ -16,9 +16,9 @@ nvm use 20
 # Package the extension
 npx vsce package --allow-missing-repository
 
-# Install to Windows VS Code
-echo "Installing to Windows VS Code..."
-cmd.exe /c "code --install-extension $(wslpath -w "$(pwd)/claude-agents-${VERSION}.vsix") --force"
+# Install to VS Code (WSL mode - uses VS Code Server in WSL)
+echo "Installing to VS Code (WSL)..."
+code --install-extension "$(pwd)/claude-agents-${VERSION}.vsix" --force
 
 echo ""
 echo "Done! Reload VS Code to use v${VERSION}"

--- a/vscode-extension/src/pathUtils.ts
+++ b/vscode-extension/src/pathUtils.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+import * as os from 'os';
+import * as childProcess from 'child_process';
 
 /**
  * Unified path handling for cross-platform compatibility.
@@ -7,34 +9,70 @@ import * as vscode from 'vscode';
  * This class ensures paths are always converted to the correct format for each context.
  *
  * Path contexts:
- * - nodeFs: For Node.js fs operations (always Windows format on Windows)
+ * - nodeFs: For Node.js fs operations (always Windows format on Windows, or UNC for WSL native paths)
  * - terminal: For terminal commands (WSL: /mnt/c/..., Git Bash: /c/..., Windows: C:\...)
  * - display: For showing to users (Windows format)
+ *
+ * Path types handled:
+ * - Windows: C:\Users\... or C:/Users/...
+ * - WSL mounted: /mnt/c/Users/...
+ * - WSL native: /home/user/... (converted to \\wsl.localhost\<distro>\home\user\... for Windows)
+ * - Git Bash: /c/Users/...
+ * - UNC WSL: \\wsl.localhost\<distro>\... or \\wsl$\<distro>\...
  */
 export class AgentPath {
     private readonly originalPath: string;
     private readonly drive: string;
     private readonly restPath: string;
+    private readonly isWslNative: boolean;
+    private readonly wslDistro: string;
 
     constructor(inputPath: string) {
         this.originalPath = inputPath;
+        this.isWslNative = false;
+        this.wslDistro = '';
 
         // Parse the path to extract drive and rest
-        const wslMatch = inputPath.match(/^\/mnt\/([a-z])\/(.*)/i);
+        const wslMountMatch = inputPath.match(/^\/mnt\/([a-z])\/(.*)/i);
         const gitBashMatch = inputPath.match(/^\/([a-z])\/(.*)/i);
         const windowsMatch = inputPath.match(/^([a-zA-Z]):[\\\/](.*)/);
+        // Match UNC paths with backslashes: \\wsl.localhost\Ubuntu\... or \\wsl$\Ubuntu\...
+        const wslUncBackslashMatch = inputPath.match(/^\\\\wsl(?:\.localhost|\$)\\([^\\]+)\\(.*)/i);
+        // Match UNC paths with forward slashes: //wsl.localhost/Ubuntu/... or //wsl$/Ubuntu/...
+        const wslUncForwardMatch = inputPath.match(/^\/\/wsl(?:\.localhost|\$)\/([^\/]+)\/(.*)/i);
 
-        if (wslMatch) {
-            this.drive = wslMatch[1].toLowerCase();
-            this.restPath = wslMatch[2].replace(/\\/g, '/');
+        if (wslUncBackslashMatch) {
+            // UNC path to WSL with backslashes: \\wsl.localhost\Ubuntu\home\user
+            this.drive = '';
+            this.wslDistro = wslUncBackslashMatch[1];
+            this.restPath = '/' + wslUncBackslashMatch[2].replace(/\\/g, '/');
+            this.isWslNative = true;
+        } else if (wslUncForwardMatch) {
+            // UNC path to WSL with forward slashes: //wsl.localhost/Ubuntu/home/user
+            this.drive = '';
+            this.wslDistro = wslUncForwardMatch[1];
+            this.restPath = '/' + wslUncForwardMatch[2];
+            this.isWslNative = true;
+        } else if (wslMountMatch) {
+            // WSL mounted Windows drive: /mnt/c/Users/...
+            this.drive = wslMountMatch[1].toLowerCase();
+            this.restPath = wslMountMatch[2].replace(/\\/g, '/');
         } else if (windowsMatch) {
+            // Windows path: C:\Users\... or C:/Users/...
             this.drive = windowsMatch[1].toLowerCase();
             this.restPath = windowsMatch[2].replace(/\\/g, '/');
-        } else if (gitBashMatch && !inputPath.startsWith('/mnt/')) {
+        } else if (gitBashMatch && !inputPath.startsWith('/mnt/') && gitBashMatch[1].length === 1) {
+            // Git Bash path: /c/Users/...
             this.drive = gitBashMatch[1].toLowerCase();
             this.restPath = gitBashMatch[2].replace(/\\/g, '/');
+        } else if (inputPath.startsWith('/') && !inputPath.startsWith('/mnt/')) {
+            // WSL native path: /home/user/... (not a mounted drive)
+            this.drive = '';
+            this.restPath = inputPath;
+            this.isWslNative = true;
+            this.wslDistro = getWslDistro();
         } else {
-            // Unknown format - assume it's a relative path or unix path without drive
+            // Unknown format - assume it's a relative path
             this.drive = '';
             this.restPath = inputPath.replace(/\\/g, '/');
         }
@@ -42,13 +80,42 @@ export class AgentPath {
 
     /**
      * Get path for Node.js fs operations.
-     * Always returns Windows format (C:/...) since the extension runs on Windows.
+     * Returns appropriate format based on the platform Node.js is running on:
+     * - On Windows: C:/... for Windows drives, UNC paths for WSL native paths
+     * - On Linux (WSL VS Code): /mnt/c/... for Windows drives, native paths for Linux paths
      */
     forNodeFs(): string {
-        if (!this.drive) {
-            return this.restPath;
+        const platform = os.platform();
+        let result: string;
+
+        // If running on Linux (e.g., WSL VS Code with Remote - WSL extension),
+        // Node.js fs uses Linux paths
+        if (platform !== 'win32') {
+            if (this.isWslNative) {
+                // Already a native Linux path
+                result = this.restPath;
+            } else if (this.drive) {
+                // Windows drive letter - convert to WSL mount path
+                result = `/mnt/${this.drive}/${this.restPath}`;
+            } else {
+                // Pure Unix path
+                result = this.restPath;
+            }
+        } else {
+            // On Windows Node.js
+            if (this.isWslNative && this.wslDistro) {
+                // Convert WSL native path to UNC path accessible from Windows Node.js
+                // /home/user/... -> \\wsl.localhost\Ubuntu\home\user\...
+                // Note: Node.js fs on Windows requires backslash UNC paths
+                result = `\\\\wsl.localhost\\${this.wslDistro}${this.restPath.replace(/\//g, '\\')}`;
+            } else if (!this.drive) {
+                result = this.restPath;
+            } else {
+                result = `${this.drive.toUpperCase()}:/${this.restPath}`;
+            }
         }
-        return `${this.drive.toUpperCase()}:/${this.restPath}`;
+
+        return result;
     }
 
     /**
@@ -57,26 +124,50 @@ export class AgentPath {
     forTerminal(): string {
         const terminalType = vscode.workspace.getConfiguration('claudeAgents')
             .get<string>('terminalType', 'wsl');
+        let result: string;
 
-        if (!this.drive) {
+        // WSL native paths stay as-is for WSL terminals
+        if (this.isWslNative) {
+            if (terminalType === 'wsl' || terminalType === 'bash') {
+                result = this.restPath;
+            } else if (this.wslDistro) {
+                // For Windows terminals, use UNC path
+                result = `\\\\wsl.localhost\\${this.wslDistro}${this.restPath.replace(/\//g, '\\')}`;
+            } else {
+                result = this.restPath;
+            }
+        } else if (!this.drive) {
             // Unix path without drive letter (macOS/Linux) - return as-is
-            return this.restPath.startsWith('/') ? this.restPath : `/${this.restPath}`;
+            result = this.restPath.startsWith('/') ? this.restPath : `/${this.restPath}`;
+        } else {
+            switch (terminalType) {
+                case 'wsl':
+                    result = `/mnt/${this.drive}/${this.restPath}`;
+                    break;
+                case 'gitbash':
+                    result = `/${this.drive}/${this.restPath}`;
+                    break;
+                case 'bash':
+                    // Native bash - if we have a Windows drive letter, we're likely in WSL
+                    // accessing Windows files, so use WSL mount path format
+                    if (this.drive) {
+                        result = `/mnt/${this.drive}/${this.restPath}`;
+                    } else {
+                        // Pure Unix path without drive letter
+                        result = this.restPath.startsWith('/') ? this.restPath : `/${this.restPath}`;
+                    }
+                    break;
+                case 'powershell':
+                case 'cmd':
+                    result = `${this.drive.toUpperCase()}:\\${this.restPath.replace(/\//g, '\\')}`;
+                    break;
+                default:
+                    result = this.forNodeFs();
+                    break;
+            }
         }
 
-        switch (terminalType) {
-            case 'wsl':
-                return `/mnt/${this.drive}/${this.restPath}`;
-            case 'gitbash':
-                return `/${this.drive}/${this.restPath}`;
-            case 'bash':
-                // Native bash (macOS/Linux) - shouldn't have drive letters, but handle gracefully
-                return `/${this.restPath}`;
-            case 'powershell':
-            case 'cmd':
-                return `${this.drive.toUpperCase()}:\\${this.restPath.replace(/\//g, '\\')}`;
-            default:
-                return this.forNodeFs();
-        }
+        return result;
     }
 
     /**
@@ -93,7 +184,20 @@ export class AgentPath {
      * Join a subpath to this path, returning a new AgentPath.
      */
     join(...parts: string[]): AgentPath {
-        const joined = [this.forNodeFs(), ...parts].join('/').replace(/\/+/g, '/');
+        const base = this.forNodeFs();
+        // For backslash UNC paths, use backslash separator
+        const sep = base.startsWith('\\\\') ? '\\' : '/';
+        let joined = [base, ...parts].join(sep);
+        // Normalize separators
+        if (base.startsWith('\\\\')) {
+            // Backslash UNC path - normalize to backslashes, preserve leading \\
+            joined = '\\\\' + joined.slice(2).replace(/[\\/]+/g, '\\');
+        } else if (joined.startsWith('//')) {
+            // Forward slash UNC path - preserve leading //
+            joined = '//' + joined.slice(2).replace(/\/+/g, '/');
+        } else {
+            joined = joined.replace(/\/+/g, '/');
+        }
         return new AgentPath(joined);
     }
 
@@ -110,4 +214,83 @@ export class AgentPath {
  */
 export function agentPath(inputPath: string): AgentPath {
     return new AgentPath(inputPath);
+}
+
+/**
+ * Cached WSL distro name
+ */
+let cachedWslDistro: string | null = null;
+
+/**
+ * Get the default WSL distribution name.
+ * Caches the result for performance.
+ */
+export function getWslDistro(): string {
+    if (cachedWslDistro !== null) {
+        return cachedWslDistro;
+    }
+
+    // Check if we're on Windows
+    if (os.platform() !== 'win32') {
+        cachedWslDistro = '';
+        return cachedWslDistro;
+    }
+
+    try {
+        // Get the default WSL distro using wsl.exe
+        const result = childProcess.execSync('wsl.exe -l -q', {
+            encoding: 'utf-8',
+            timeout: 5000,
+            windowsHide: true,
+        });
+
+        // The first line is the default distro (remove null chars from UTF-16 output)
+        const lines = result.replace(/\0/g, '').trim().split('\n');
+        cachedWslDistro = lines[0]?.trim() || '';
+    } catch {
+        // WSL not available or error
+        cachedWslDistro = '';
+    }
+
+    return cachedWslDistro;
+}
+
+/**
+ * Get the home directory path appropriate for the current environment.
+ * - On Linux (WSL VS Code): returns the native Linux home directory
+ * - On Windows with WSL terminal type: returns the WSL home directory
+ * - Otherwise: returns the native home directory
+ */
+export function getHomeDir(): AgentPath {
+    // If running on Linux (e.g., WSL VS Code), just use native home
+    if (os.platform() !== 'win32') {
+        return new AgentPath(os.homedir());
+    }
+
+    // On Windows, check terminal type
+    const terminalType = vscode.workspace.getConfiguration('claudeAgents')
+        .get<string>('terminalType', 'wsl');
+
+    if (terminalType === 'wsl') {
+        const distro = getWslDistro();
+        if (distro) {
+            try {
+                // Get WSL home directory using wsl.exe
+                const result = childProcess.execSync('wsl.exe -e sh -c "echo $HOME"', {
+                    encoding: 'utf-8',
+                    timeout: 5000,
+                    windowsHide: true,
+                });
+                const wslHome = result.trim();
+                if (wslHome) {
+                    return new AgentPath(wslHome);
+                }
+            } catch {
+                // Fall through to Windows home
+            }
+        }
+    }
+
+    // Default to Windows/native home directory
+    return new AgentPath(os.homedir());
 }

--- a/vscode-extension/src/services/TodoService.ts
+++ b/vscode-extension/src/services/TodoService.ts
@@ -1,0 +1,236 @@
+/**
+ * TodoService - Claude Code TODO list reader
+ *
+ * Reads TODO lists from Claude Code's ~/.claude/todos directory.
+ * TODOs are stored per-session in JSON files.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { getHomeDir } from '../pathUtils';
+import { getLogger, isLoggerInitialized } from './Logger';
+
+/**
+ * Single TODO item from Claude Code
+ */
+export interface TodoItem {
+    content: string;
+    status: 'pending' | 'in_progress' | 'completed';
+    activeForm?: string;
+    id?: string;
+    priority?: string;
+}
+
+/**
+ * Complete TODO state for a session
+ */
+export interface TodoState {
+    items: TodoItem[];
+    sessionId: string;
+    lastModified: Date;
+}
+
+/**
+ * Service for reading Claude Code TODO lists
+ */
+export class TodoService {
+    private _todosDir: string | null = null;
+
+    /**
+     * Get the todos directory path (computed lazily to ensure VS Code is initialized)
+     */
+    private get todosDir(): string {
+        if (this._todosDir === null) {
+            // Claude Code stores TODOs in ~/.claude/todos
+            // Use getHomeDir() to get the correct home directory for the terminal type (WSL, Windows, etc.)
+            const home = getHomeDir();
+            const homeNodeFs = home.forNodeFs();
+            const joined = home.join('.claude', 'todos');
+            const joinedNodeFs = joined.forNodeFs();
+            this._todosDir = joinedNodeFs;
+            if (isLoggerInitialized()) {
+                const logger = getLogger().child('TodoService');
+                logger.debug(`home.forNodeFs(): ${homeNodeFs}`);
+                logger.debug(`joined.forNodeFs(): ${joinedNodeFs}`);
+                logger.debug(`Todos directory: ${this._todosDir}`);
+            }
+        }
+        return this._todosDir;
+    }
+
+    constructor() {
+        // Path is computed lazily in the getter
+    }
+
+    /**
+     * Get the most recent TODO list from Claude Code
+     */
+    getCurrentTodos(): TodoState | null {
+        try {
+            if (!fs.existsSync(this.todosDir)) {
+                return null;
+            }
+
+            const files = fs.readdirSync(this.todosDir);
+            if (files.length === 0) {
+                return null;
+            }
+
+            // Find the most recently modified TODO file
+            const latestFile = this.findLatestFile(files);
+            if (!latestFile) {
+                return null;
+            }
+
+            const content = fs.readFileSync(latestFile.path, 'utf-8').trim();
+            if (!content || content === '[]') {
+                return null;
+            }
+
+            const items = JSON.parse(content) as TodoItem[];
+            if (!Array.isArray(items) || items.length === 0) {
+                return null;
+            }
+
+            // Extract session ID from filename
+            const sessionId = path.basename(latestFile.path, '.json').split('-agent-')[0];
+
+            return {
+                items,
+                sessionId,
+                lastModified: latestFile.mtime,
+            };
+        } catch (error) {
+            if (isLoggerInitialized()) {
+                getLogger().child('TodoService').debug('Failed to read TODOs', error);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Get TODOs for a specific session ID (if available)
+     */
+    getTodosForSession(sessionId: string): TodoItem[] | null {
+        const logger = isLoggerInitialized() ? getLogger().child('TodoService') : null;
+        try {
+            logger?.debug(`Looking for TODOs for session: ${sessionId}`);
+            logger?.debug(`Todos directory: ${this.todosDir}`);
+
+            if (!fs.existsSync(this.todosDir)) {
+                logger?.debug(`Todos directory does not exist`);
+                return null;
+            }
+
+            const files = fs.readdirSync(this.todosDir);
+            logger?.debug(`Found ${files.length} files in todos directory`);
+
+            // Find all files that match this session ID
+            const matchingFiles = files.filter(f => f.includes(sessionId) && f.endsWith('.json'));
+            logger?.debug(`Matching files for session ${sessionId}: ${matchingFiles.join(', ') || 'none'}`);
+
+            if (matchingFiles.length === 0) {
+                return null;
+            }
+
+            // Sort by modification time (most recent first) and find first with content
+            const sortedFiles = matchingFiles
+                .map(f => {
+                    const filePath = path.join(this.todosDir, f);
+                    try {
+                        const stat = fs.statSync(filePath);
+                        return { path: filePath, mtime: stat.mtimeMs };
+                    } catch {
+                        return null;
+                    }
+                })
+                .filter((f): f is { path: string; mtime: number } => f !== null)
+                .sort((a, b) => b.mtime - a.mtime);
+
+            // Try each file until we find one with content
+            for (const file of sortedFiles) {
+                const content = fs.readFileSync(file.path, 'utf-8').trim();
+                if (content && content !== '[]') {
+                    const items = JSON.parse(content) as TodoItem[];
+                    if (Array.isArray(items) && items.length > 0) {
+                        return items;
+                    }
+                }
+            }
+
+            return null;
+        } catch (error) {
+            if (isLoggerInitialized()) {
+                getLogger().child('TodoService').debug('Failed to read session TODOs', error);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Get the active (in_progress) TODO item if any
+     */
+    getActiveTodo(): TodoItem | null {
+        const state = this.getCurrentTodos();
+        if (!state) {
+            return null;
+        }
+
+        return state.items.find(item => item.status === 'in_progress') || null;
+    }
+
+    /**
+     * Find the most recently modified file in the todos directory
+     */
+    private findLatestFile(files: string[]): { path: string; mtime: Date } | null {
+        let latestFile = '';
+        let latestTime = 0;
+        let latestMtime: Date | null = null;
+
+        for (const file of files) {
+            if (!file.endsWith('.json')) {
+                continue;
+            }
+
+            const filePath = path.join(this.todosDir, file);
+            try {
+                const stat = fs.statSync(filePath);
+                if (stat.mtimeMs > latestTime) {
+                    latestTime = stat.mtimeMs;
+                    latestFile = filePath;
+                    latestMtime = stat.mtime;
+                }
+            } catch {
+                // Skip files we can't stat
+            }
+        }
+
+        if (!latestFile || !latestMtime) {
+            return null;
+        }
+
+        return { path: latestFile, mtime: latestMtime };
+    }
+}
+
+/**
+ * Singleton instance
+ */
+let todoServiceInstance: TodoService | null = null;
+
+/**
+ * Get the global TodoService instance
+ */
+export function getTodoService(): TodoService {
+    if (!todoServiceInstance) {
+        todoServiceInstance = new TodoService();
+    }
+    return todoServiceInstance;
+}
+
+/**
+ * Reset the global TodoService instance (for testing)
+ */
+export function resetTodoService(): void {
+    todoServiceInstance = null;
+}

--- a/vscode-extension/src/services/index.ts
+++ b/vscode-extension/src/services/index.ts
@@ -18,3 +18,4 @@ export {
     isPersistenceServiceInitialized,
     resetPersistenceService,
 } from './PersistenceService';
+export { TodoService, TodoItem, TodoState, getTodoService, resetTodoService } from './TodoService';


### PR DESCRIPTION
## Summary

- Add TodoService to read Claude Code's TODO lists from `~/.claude/todos` and display per-agent progress in the dashboard
- Fix path handling for WSL VS Code (Remote - WSL extension) so the extension works when running in WSL
- Show activeForm text (italic, green) for in-progress tasks instead of duplicating both forms

## Changes

### TODO Display
- New `TodoService` reads Claude Code TODO files per session ID
- Dashboard shows TODO progress with status indicators (○ pending, ▶ in progress, ✓ completed)
- In-progress tasks show the `activeForm` text (e.g., "Testing hook functionality") in green italics

### WSL Remote Support
- Detect `os.platform()` to differentiate Linux (WSL VS Code) vs Windows Node.js
- Execute commands directly with bash when running on Linux instead of calling `wsl bash -c ...`
- Path conversion handles Windows paths → `/mnt/c/...` format in WSL context
- Updated `compile_and_install.sh` for WSL VS Code installation

### Documentation
- Updated CLAUDE.md with Logger service usage (never use console.log)
- Added WSL native path handling documentation

## Test plan

- [x] Create agents in WSL VS Code - works without "Not a git repository" error
- [x] TODO list displays correctly with per-agent session matching
- [x] In-progress tasks show activeForm in green italics
- [x] Completed tasks show strikethrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)