### PR TITLE
Fix repository selection and add grouped UI by repo

### DIFF
--- a/vscode-extension/compile_and_install.sh
+++ b/vscode-extension/compile_and_install.sh
@@ -3,8 +3,9 @@
 
 set -e
 
-# Get version from package.json
+# Get version and name from package.json
 VERSION=$(grep '"version"' package.json | head -1 | sed 's/.*: "\(.*\)".*/\1/')
+NAME=$(grep '"name"' package.json | head -1 | sed 's/.*: "\(.*\)".*/\1/')
 
 echo "Building Claude Agents extension v${VERSION}..."
 
@@ -18,7 +19,7 @@ npx vsce package --allow-missing-repository
 
 # Install to VS Code (WSL mode - uses VS Code Server in WSL)
 echo "Installing to VS Code (WSL)..."
-code --install-extension "$(pwd)/claude-agents-${VERSION}.vsix" --force
+code --install-extension "$(pwd)/${NAME}-${VERSION}.vsix" --force
 
 echo ""
 echo "Done! Reload VS Code to use v${VERSION}"

--- a/vscode-extension/src/agentManager.ts
+++ b/vscode-extension/src/agentManager.ts
@@ -36,7 +36,6 @@ export { Agent, AgentStatus, PersistedAgent, DiffStats, PendingApproval, Isolati
  */
 export class AgentManager {
     private agents: Map<number, Agent> = new Map();
-    private workspaceRoot: string;
     private extensionPath: string;
 
     // Specialized managers
@@ -46,7 +45,6 @@ export class AgentManager {
     private persistence: AgentPersistence;
 
     constructor(extensionPath: string) {
-        this.workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '';
         this.extensionPath = extensionPath;
 
         // Initialize managers
@@ -54,6 +52,13 @@ export class AgentManager {
         this.worktreeManager = new WorktreeManager(extensionPath);
         this.statusTracker = new AgentStatusTracker();
         this.persistence = new AgentPersistence(this.worktreeManager, this.containerManager);
+    }
+
+    /**
+     * Get the current workspace root (dynamically, not cached)
+     */
+    private get workspaceRoot(): string {
+        return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '';
     }
 
     private get worktreeDir(): string {

--- a/vscode-extension/src/test/suite/agentPanel.test.ts
+++ b/vscode-extension/src/test/suite/agentPanel.test.ts
@@ -37,7 +37,7 @@ suite('AgentPanel HTML Test Suite', () => {
     test('Button actions should have matching data-action attributes in HTML', () => {
         const handledActions = [
             'focus', 'startClaude', 'sendKey', 'deleteAgent',
-            'viewDiff', 'createAgents', 'addAgent', 'refresh'
+            'viewDiff', 'createAgents', 'addAgentToRepo'
         ];
 
         for (const action of handledActions) {


### PR DESCRIPTION
## Summary

### Repository Selection Fixes
- ConfigService now refreshes after settings are saved (fixes stale repo bug)
- workspaceRoot is now a dynamic getter instead of cached value
- Agents now created in correct repo when settings change

### New Features
- Git repo path validation in settings (validates on blur/browse with check/x icons)
- Dashboard groups agents by repository with section headers
- Each repo section has its own Add Agent button
- Empty configured repos shown with placeholder
- UI scale setting moved to settings panel

### UI Improvements
- Renamed to Opus Orchestra Dashboard
- Title moved into stats bar
- Removed header divider and refresh button

## Test plan
- [ ] Verify changing repo path creates agents in correct repo
- [ ] Verify invalid repo paths show X in settings
- [ ] Verify agents grouped by repo in dashboard
- [x] Run npm run lint - passes
- [x] Run agentPanel tests - 7/7 passing

Generated with [Claude Code](https://claude.com/claude-code)