### PR TITLE
Fix extension test publisher ID

### DIFF
--- a/packages/vscode/src/test/suite/extension.test.ts
+++ b/packages/vscode/src/test/suite/extension.test.ts
@@ -5,11 +5,11 @@ suite('Extension Test Suite', () => {
     vscode.window.showInformationMessage('Start all tests.');
 
     test('Extension should be present', () => {
-        assert.ok(vscode.extensions.getExtension('your-publisher-id.opus-orchestra'));
+        assert.ok(vscode.extensions.getExtension('kyleherndon.opus-orchestra'));
     });
 
     test('Extension should activate', async () => {
-        const ext = vscode.extensions.getExtension('your-publisher-id.opus-orchestra');
+        const ext = vscode.extensions.getExtension('kyleherndon.opus-orchestra');
         assert.ok(ext);
         await ext!.activate();
         assert.ok(ext!.isActive);


### PR DESCRIPTION
## Summary
- Fix failing tests by updating placeholder `your-publisher-id` to actual publisher `kyleherndon` in extension.test.ts

## Test plan
- [x] All 129 VSCode tests now pass
- [x] All 70 core tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)